### PR TITLE
fix(Coupon): Coupon ID Was Squashing Coupon Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage
 config.json
 .idea
 npm-debug.log
+.vscode

--- a/lib/models/coupon.js
+++ b/lib/models/coupon.js
@@ -14,6 +14,7 @@ class Coupon extends RecurlyData {
     super({
       recurring,
       properties: [
+        'id',
         'applies_for_months',
         'applies_to_all_plans',
         'applies_to_non_plan_charges',
@@ -41,7 +42,7 @@ class Coupon extends RecurlyData {
         'temporal_unit',
         'unique_code_template'
       ],
-      idField: 'coupon_code',
+      idField: 'id',
       plural: 'coupons',
       singular: 'coupon',
       enumerable: true


### PR DESCRIPTION
Coupon Code was being squashed by coupon id because it was listed as the id field. This prevents scenarios when the engineer wants to display a list of coupons and the corresponding coupon codes used for redemption